### PR TITLE
Fix elb_cleanup lambda prefix to use underscore.

### DIFF
--- a/elb-cleanup/config.go
+++ b/elb-cleanup/config.go
@@ -28,7 +28,7 @@ func (c *config) Validate() error {
 // Set the file name of the configurations file
 func init() {
 	viper.AutomaticEnv()
-	viper.SetEnvPrefix("elb-cleanup")
+	viper.SetEnvPrefix("elb_cleanup")
 
 	defaults := map[string]interface{}{
 		"debug":       false,


### PR DESCRIPTION
Issue: CLD-5299

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fix elb_cleanup lambda prefix to use underscore.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-5313

