### PR TITLE
Add /api/webhook and /api/webhooks to the authorized provisioner auth routes

### DIFF
--- a/cloud-server-auth/main.go
+++ b/cloud-server-auth/main.go
@@ -100,6 +100,10 @@ func isAuthorized(url *url.URL) bool {
 		"/api/installation",
 		"api/cluster_installation",
 		"/api/cluster_installation",
+		"api/webhooks",
+		"/api/webhooks",
+		"/api/webhook",
+		"api/webhook",
 	}
 
 	for _, prefix := range validPrefixes {


### PR DESCRIPTION
#### Summary
Adds 2 authorized routes leveraged by Matterwick as of https://github.com/mattermost/matterwick/pull/38

#### Ticket Link
N/A

