### PR TITLE
[CLD-5977] Add support for exact regex matching on endpoints

### DIFF
--- a/cloud-server-auth/main.go
+++ b/cloud-server-auth/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -108,6 +109,18 @@ func isAuthorized(url *url.URL) bool {
 
 	for _, prefix := range validPrefixes {
 		if strings.HasPrefix(url.EscapedPath(), prefix) {
+			return true
+		}
+	}
+
+	// These endpoints require an exact match, so the cloud plugin can talk to some but not all security endpoints.
+	exactMatchRegexes := []string{
+		"^/api/security/installation/[a-zA-Z0-9]{26}/deletion/lock$",
+		"^/api/security/installation/[a-zA-Z0-9]{26}/deletion/unlock$",
+	}
+
+	for _, regex := range exactMatchRegexes {
+		if matched, _ := regexp.MatchString(regex, url.EscapedPath()); matched {
 			return true
 		}
 	}


### PR DESCRIPTION
#### Summary
I've added support for installation deletion locks in https://github.com/mattermost/mattermost-cloud/pull/943 and want to expose these new endpoints to the cloud plugin here: https://github.com/mattermost/mattermost-plugin-cloud/pull/128

In order to do this, we need to allow the requests to these endpoints through. I didn't want to open up all of the security endpoints to the cloud plugin, so added some functionality to enforce an exact match. The regex provided should only allow requests to the new endpoints exactly, and nothing else. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-5977

