### PR TITLE
Disable CGO for cloud-server-auth lambda

### DIFF
--- a/cloud-server-auth/Makefile
+++ b/cloud-server-auth/Makefile
@@ -9,7 +9,7 @@ all: build pack
 
 build:
 	@echo "Building..."
-	@GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags='-w -s' -o $(HANDLER)
+	@GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags='-w -s' -o $(HANDLER)
 
 pack: build
 	@echo "Packing binary..."


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost-cloud-lambdas/pull/13 added CGO_ENABLED=0 to a bunch of the lambdas but this one seems to have been missed. Adding it here. 
#### Ticket Link
N/A

